### PR TITLE
Add return value to zRevRank

### DIFF
--- a/src/Redis.php
+++ b/src/Redis.php
@@ -2339,8 +2339,10 @@ class Redis
 
     /**
      * @see zRank()
-     * @param string $key
-     * @param string $member
+     * @param  string $key
+     * @param  string $member
+     * @return int    the item's score
+     * @link   http://redis.io/commands/zrevrank
      */
     public function zRevRank( $key, $member ) {}
 


### PR DESCRIPTION
Without the return value, my IDE (PhpStorm) assumes the function returns void:

![Before fix](http://i.imgur.com/pZYBfXT.png)

After applying this change the error went away:

![After fix](http://i.imgur.com/tLaPFjL.png)

(I also included the link to the Redis documentation for completeness)
