### PR TITLE
Add return type for exec() to get rid of warning

### DIFF
--- a/src/Redis.php
+++ b/src/Redis.php
@@ -306,6 +306,7 @@ class Redis
 
     /**
      * @see multi()
+     * @return void|array
      * @link    http://redis.io/commands/exec
      */
     public function exec( ) {}


### PR DESCRIPTION
In some cases `exec()` may return array of results.