### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/src/Redis.php
+++ b/src/Redis.php
@@ -3555,7 +3555,7 @@ class RedisArray {
      * @param   array          $opts   Array of options
      * @link    https://github.com/nicolasff/phpredis/blob/master/arrays.markdown
      */
-    function __construct($hosts, array $opts = NULL) {}
+    function __construct($hosts, array $opts = null) {}
 
     /**
      * @return  array   list of hosts for the selected array


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!