### PR TITLE
Redis.hDel may return false

### DIFF
--- a/src/Redis.php
+++ b/src/Redis.php
@@ -3617,7 +3617,7 @@ class Redis
      * @param string $hashKey1
      * @param string ...$otherHashKeys
      *
-     * @return int Number of deleted fields
+     * @return int|false Number of deleted fields
      *
      * @link    https://redis.io/commands/hdel
      * @example


### PR DESCRIPTION
Redis.hDel may return false if the hash table doesn't exist, or the key doesn't exist