### PR TITLE
Fixed in the example the use of SCAN function

### DIFF
--- a/src/Redis.php
+++ b/src/Redis.php
@@ -4548,7 +4548,7 @@ class Redis
      * @example
      * <pre>
      * $iterator = null;
-     * while($keys = $redis->scan($iterator)) {
+     * while(false !== ($keys = $redis->scan($iterator))) {
      *     foreach($keys as $key) {
      *         echo $key . PHP_EOL;
      *     }


### PR DESCRIPTION
The example of using SCAN did not work properly if $pattern was used.
If we do not test the return is FALSE (end of scan) and we used $pattern (Redis MATCH option) the scan function can return empty lists because of the way it works, but we still have to keep going through the list until the function returns FALSE.
More information on this feature of Redis in the doc with the MATCH option: https://redis.io/commands/scan#the-match-option