### PR TITLE
Fixed a typo in the Redis.sRandMember var_dump() output

### DIFF
--- a/src/Redis.php
+++ b/src/Redis.php
@@ -1569,7 +1569,7 @@ class Redis
      *
      * // array(2) {
      * //   [0]=> string(2) "one"
-     * //   [1]=> string(2) "three"
+     * //   [1]=> string(5) "three"
      * // }
      * </pre>
      */


### PR DESCRIPTION
There was a very minor typo in the `var_dump()` output. The length of the string `"three"` is 5. Previously this was displaying a length of 2 (likely from duplicating and editing the previous line).