### PR TITLE
Add missing  option for flushDB() and flushAll()

### DIFF
--- a/src/Redis.php
+++ b/src/Redis.php
@@ -2590,23 +2590,30 @@ class Redis
     /**
      * Removes all entries from the current database.
      *
+     * @param bool $async
+     *
      * @return bool Always TRUE
+     *
+     * @since   phpredis 4.1 The $async option was added
      * @link    https://redis.io/commands/flushdb
      * @example $redis->flushDB();
      */
-    public function flushDB()
+    public function flushDB($async)
     {
     }
 
     /**
      * Removes all entries from all databases.
      *
+     * @param bool $async
+     *
      * @return bool Always TRUE
      *
+     * @since   phpredis 4.1 The $async option was added
      * @link    https://redis.io/commands/flushall
      * @example $redis->flushAll();
      */
-    public function flushAll()
+    public function flushAll($async)
     {
     }
 


### PR DESCRIPTION
An `$async` option was added in phpredis 4.1 for methods `flushDB()` and `flushAll()` but it was forgotten in their doc.

**Question:** I am not sure about how to say the argument is available since phpredis 4.1, WDYT?